### PR TITLE
Add query for finding available interviewers

### DIFF
--- a/app/controllers/candidates_controller.go
+++ b/app/controllers/candidates_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -127,16 +128,26 @@ func CandidateAvailabilityIndexHandler(w http.ResponseWriter, r *http.Request) {
 	queryString := r.URL.Query()
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
+	all := false
+	var err error
+
+	if (len(queryString) > 0) && (len(queryString["all"]) > 0) {
+		all, err = strconv.ParseBool(queryString["all"][0])
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	if (len(queryString) > 0) && (len(queryString["interviewer"]) > 0) {
 		interviewersIds := queryString["interviewer"]
-		body := queries.FindCandidateAndInterviewerTimeSlot(cid, interviewersIds)
+		body := queries.ListCandidateAndInterviewerTimeSlot(cid, interviewersIds, all)
 
 		if err := json.NewEncoder(w).Encode(body); err != nil {
 			log.Fatal(err)
 		}
 	} else {
-		body := queries.ListCandidateTimeSlots(cid)
+		body := queries.ListCandidateTimeSlots(cid, all)
 
 		if err := json.NewEncoder(w).Encode(body); err != nil {
 			log.Fatal(err)

--- a/app/controllers/candidates_controller.go
+++ b/app/controllers/candidates_controller.go
@@ -124,12 +124,23 @@ func DeleteCandidatesHandler(w http.ResponseWriter, r *http.Request) {
 
 func CandidateAvailabilityIndexHandler(w http.ResponseWriter, r *http.Request) {
 	cid := strings.Split(r.URL.Path, "/")[2]
+	queryString := r.URL.Query()
 	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	w.WriteHeader(http.StatusOK)
-	body := queries.ListCandidateTimeSlots(cid)
 
-	if err := json.NewEncoder(w).Encode(body); err != nil {
-		log.Fatal(err)
+	if (len(queryString) > 0) && (len(queryString["interviewer"]) > 0) {
+		interviewersIds := queryString["interviewer"]
+		body := queries.FindCandidateAndInterviewerTimeSlot(cid, interviewersIds)
+
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		body := queries.ListCandidateTimeSlots(cid)
+
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			log.Fatal(err)
+		}
 	}
 }
 

--- a/app/routes/routes.go
+++ b/app/routes/routes.go
@@ -52,6 +52,35 @@ func candidatesResources(r *mux.Router) *mux.Router {
 	return r
 }
 
+func candidatesAvailabilityResources(r *mux.Router) *mux.Router {
+	r.HandleFunc(
+		"/candidates/{cid}/availability/{id}",
+		controllers.DeleteCandidateAvailabilityHandler,
+	).Methods("DELETE")
+
+	r.HandleFunc(
+		"/candidates/{cid}/availability/{id}",
+		controllers.EditCandidateAvailabilityHandler,
+	).Methods("PATCH")
+
+	r.HandleFunc(
+		"/candidates/{cid}/availability/{id}",
+		controllers.ShowCandidateAvailabilityHandler,
+	).Methods("GET")
+
+	r.HandleFunc(
+		"/candidates/{cid}/availability",
+		controllers.NewCandidateAvailabilityHandler,
+	).Methods("POST")
+
+	r.HandleFunc(
+		"/candidates/{cid}/availability",
+		controllers.CandidateAvailabilityIndexHandler,
+	).Methods("GET")
+
+	return r
+}
+
 func interviewersAvailabilityResources(r *mux.Router) *mux.Router {
 	r.HandleFunc(
 		"/interviewers/{iid}/availability/{id}",
@@ -105,35 +134,6 @@ func interviewersResources(r *mux.Router) *mux.Router {
 	r.HandleFunc(
 		"/interviewers",
 		controllers.InterviewersIndexHandler,
-	).Methods("GET")
-
-	return r
-}
-
-func candidatesAvailabilityResources(r *mux.Router) *mux.Router {
-	r.HandleFunc(
-		"/candidates/{cid}/availability/{id}",
-		controllers.DeleteCandidateAvailabilityHandler,
-	).Methods("DELETE")
-
-	r.HandleFunc(
-		"/candidates/{cid}/availability/{id}",
-		controllers.EditCandidateAvailabilityHandler,
-	).Methods("PATCH")
-
-	r.HandleFunc(
-		"/candidates/{cid}/availability/{id}",
-		controllers.ShowCandidateAvailabilityHandler,
-	).Methods("GET")
-
-	r.HandleFunc(
-		"/candidates/{cid}/availability",
-		controllers.NewCandidateAvailabilityHandler,
-	).Methods("POST")
-
-	r.HandleFunc(
-		"/candidates/{cid}/availability",
-		controllers.CandidateAvailabilityIndexHandler,
 	).Methods("GET")
 
 	return r

--- a/app/serialisers/interviewer_availability.go
+++ b/app/serialisers/interviewer_availability.go
@@ -1,0 +1,8 @@
+package serialisers
+
+import "github.com/kohrVid/calendar-api/app/models"
+
+type InterviewerAvailability struct {
+	InterviewerId int               `json:"interviewer_id"`
+	TimeSlots     []models.TimeSlot `json:"time_slots"`
+}

--- a/db/sql/queries/candidates_queries.go
+++ b/db/sql/queries/candidates_queries.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/kohrVid/calendar-api/app/models"
+	"github.com/kohrVid/calendar-api/app/serialisers"
 	"github.com/kohrVid/calendar-api/config"
 	"github.com/kohrVid/calendar-api/db"
 )
@@ -59,9 +60,9 @@ func ListCandidateTimeSlots(cid string) []models.TimeSlot {
 	      ts.end_time
 	    FROM time_slots ts
 	    INNER JOIN candidate_time_slots cts
-	    ON ts.id = cts.time_slot_id
+	      ON ts.id = cts.time_slot_id
 	    INNER JOIN candidates c
-	    ON c.id = cts.candidate_id
+	      ON c.id = cts.candidate_id
 	    WHERE c.id = ?`,
 		cid,
 	)
@@ -88,9 +89,9 @@ func FindCandidateTimeSlot(cid string, id string) (models.TimeSlot, error) {
 	      ts.end_time
 	    FROM time_slots ts
 	    INNER JOIN candidate_time_slots cts
-	    ON ts.id = cts.time_slot_id
+	      ON ts.id = cts.time_slot_id
 	    INNER JOIN candidates c
-	    ON c.id = cts.candidate_id
+	      ON c.id = cts.candidate_id
 	    WHERE c.id = ? AND ts.id = ?`,
 		cid,
 		id,
@@ -101,4 +102,86 @@ func FindCandidateTimeSlot(cid string, id string) (models.TimeSlot, error) {
 	}
 
 	return *timeSlot, nil
+}
+
+func FindCandidateAndInterviewerTimeSlot(cid string, interviewers []int) []serialisers.InterviewerAvailability {
+	conf := config.LoadConfig()
+	db := db.DBConnect(conf)
+
+	timeSlots1 := make([]models.TimeSlot, 0)
+	timeSlots2 := make([]models.TimeSlot, 0)
+	candidateAvailability := ListCandidateTimeSlots(cid)
+
+	sql := `
+	  SELECT
+	      ts.id,
+	      ts.date,
+	      ts.start_time,
+	      CASE WHEN ts.end_time > ? THEN ?
+	      ELSE ts.end_time
+	      END end_time
+	    FROM time_slots ts
+	    INNER JOIN interviewer_time_slots its
+	      ON ts.id = its.time_slot_id
+	    INNER JOIN interviewers i
+	      ON i.id = its.interviewer_id
+	    WHERE i.id = ?
+	      AND ts.date = ?
+	      AND ts.start_time >= ?
+	      AND ts.start_time < ?;`
+
+	for _, ca := range candidateAvailability {
+		ts := make([]models.TimeSlot, 0)
+		_, err := db.Query(
+			&ts,
+			sql,
+			ca.EndTime,
+			ca.EndTime,
+			interviewers[0],
+			ca.Date,
+			ca.StartTime,
+			ca.EndTime,
+		)
+
+		if err != nil {
+			fmt.Errorf("Error: %v", err)
+		}
+
+		timeSlots1 = append(timeSlots1, ts...)
+
+	}
+
+	for _, ca := range candidateAvailability {
+		ts := make([]models.TimeSlot, 0)
+		_, err := db.Query(
+			&ts,
+			sql,
+			ca.EndTime,
+			ca.EndTime,
+			interviewers[1],
+			ca.Date,
+			ca.StartTime,
+			ca.EndTime,
+		)
+
+		if err != nil {
+			fmt.Errorf("Error: %v", err)
+		}
+
+		timeSlots2 = append(timeSlots2, ts...)
+
+	}
+
+	availability := []serialisers.InterviewerAvailability{
+		serialisers.InterviewerAvailability{
+			InterviewerId: interviewers[0],
+			TimeSlots:     timeSlots1,
+		},
+		serialisers.InterviewerAvailability{
+			InterviewerId: interviewers[1],
+			TimeSlots:     timeSlots2,
+		},
+	}
+
+	return availability
 }


### PR DESCRIPTION
This PR involves:

* `FindCandidateAndInterviewerTimeSlot` queries function which will actually return the list of available time slots for a given candidate and two given interviewers
* the creation of the `InterviewerAvailability` serialiser which will be
used to more adequately format the database response.
* Update existing availability queries so that only future time slots are shown by default